### PR TITLE
Forward errors to async-next()

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,11 @@ AsyncHelpers.prototype.resolve = function(key, cb) {
       if (stashed.fn.async) {
         args = args.concat(next);
       }
-      res = stashed.fn.apply(stashed.thisArg, args);
+      try {
+        res = stashed.fn.apply(stashed.thisArg, args);
+      } catch (err) {
+        return next(err);
+      }
       if (!stashed.fn.async) {
         return next(null, res);
       }


### PR DESCRIPTION
Errors originating in helper-functions, should be passed to the next-function, so that they can be handled properly.
